### PR TITLE
Add tests and update pygdf usage

### DIFF
--- a/dask_gdf/core.py
+++ b/dask_gdf/core.py
@@ -242,8 +242,9 @@ class DataFrame(_Frame):
 
 
 def sum_of_squares(x):
-    x = x.astype('f8')
-    return gd._gdf.apply_reduce(libgdf.gdf_sum_squared_generic, x)
+    x = x.astype('f8')._column
+    outcol = gd._gdf.apply_reduce(libgdf.gdf_sum_squared_generic, x)
+    return gd.Series(outcol)
 
 
 def var_aggregate(x2, x, n, ddof=1):

--- a/dask_gdf/core.py
+++ b/dask_gdf/core.py
@@ -173,7 +173,7 @@ normalize_token.register(_Frame, lambda a: a._name)
 def query(df, expr, callenv):
     boolmask = gd.queryutils.query_execute(df, expr, callenv)
 
-    selected = gd.Series.from_array(boolmask)
+    selected = gd.Series(boolmask)
     newdf = gd.DataFrame()
     for col in df.columns:
         newseries = df[col][selected]

--- a/dask_gdf/tests/test_binops.py
+++ b/dask_gdf/tests/test_binops.py
@@ -10,7 +10,7 @@ import dask_gdf as dgd
 
 def _make_random_frame(nelem, npartitions=2):
     df = pd.DataFrame({'x': np.random.randint(0, 5, size=nelem),
-                       'y': np.random.normal(size=nelem)})
+                       'y': np.random.normal(size=nelem) + 1})
     gdf = gd.DataFrame.from_pandas(df)
     dgf = dgd.from_pygdf(gdf, npartitions=npartitions)
     return df, dgf
@@ -20,6 +20,8 @@ _binops = [
     operator.add,
     operator.sub,
     operator.mul,
+    operator.truediv,
+    operator.floordiv,
     operator.eq,
     operator.ne,
     operator.gt,
@@ -30,11 +32,11 @@ _binops = [
 
 
 @pytest.mark.parametrize('binop', _binops)
-def test_binops(binop):
+def test_series_binops(binop):
     np.random.seed(0)
     size = 10
     lhs_df, lhs_gdf = _make_random_frame(size)
     rhs_df, rhs_gdf = _make_random_frame(size)
-    got = binop(lhs_gdf.x, rhs_gdf.x)
-    exp = binop(lhs_df.x, rhs_df.x)
-    np.testing.assert_array_equal(got.compute().to_array(), exp)
+    got = binop(lhs_gdf.x, rhs_gdf.y)
+    exp = binop(lhs_df.x, rhs_df.y)
+    np.testing.assert_array_almost_equal(got.compute().to_array(), exp)

--- a/dask_gdf/tests/test_binops.py
+++ b/dask_gdf/tests/test_binops.py
@@ -1,0 +1,40 @@
+import operator
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pygdf as gd
+import dask_gdf as dgd
+
+
+def _make_random_frame(nelem, npartitions=2):
+    df = pd.DataFrame({'x': np.random.randint(0, 5, size=nelem),
+                       'y': np.random.normal(size=nelem)})
+    gdf = gd.DataFrame.from_pandas(df)
+    dgf = dgd.from_pygdf(gdf, npartitions=npartitions)
+    return df, dgf
+
+
+_binops = [
+    operator.add,
+    operator.sub,
+    operator.mul,
+    operator.eq,
+    operator.ne,
+    operator.gt,
+    operator.ge,
+    operator.lt,
+    operator.le,
+]
+
+
+@pytest.mark.parametrize('binop', _binops)
+def test_binops(binop):
+    np.random.seed(0)
+    size = 10
+    lhs_df, lhs_gdf = _make_random_frame(size)
+    rhs_df, rhs_gdf = _make_random_frame(size)
+    got = binop(lhs_gdf.x, rhs_gdf.x)
+    exp = binop(lhs_df.x, rhs_df.x)
+    np.testing.assert_array_equal(got.compute().to_array(), exp)

--- a/dask_gdf/tests/test_core.py
+++ b/dask_gdf/tests/test_core.py
@@ -4,6 +4,7 @@ from pandas.util.testing import assert_frame_equal
 
 import pygdf as gd
 import dask_gdf as dgd
+import dask.dataframe as dd
 
 
 def test_from_pygdf():
@@ -49,3 +50,17 @@ def test_head():
     dgf = dgd.from_pygdf(gdf, npartitions=2)
 
     assert_frame_equal(dgf.head().to_pandas(), df.head())
+
+
+def test_from_dask_dataframe():
+    np.random.seed(0)
+    df = pd.DataFrame({'x': np.random.randint(0, 5, size=20),
+                       'y': np.random.normal(size=20)})
+    ddf = dd.from_pandas(df, npartitions=2)
+    dgdf = dgd.from_dask_dataframe(ddf)
+    got = dgdf.compute().to_pandas()
+    expect = df
+    # Should the index be matching?
+    assert (got.index != expect.index).any()
+    np.testing.assert_array_equal(got.x.values, expect.x.values)
+    np.testing.assert_array_equal(got.y.values, expect.y.values)

--- a/dask_gdf/tests/test_core.py
+++ b/dask_gdf/tests/test_core.py
@@ -39,3 +39,13 @@ def test_query():
     expect = gdf.query(expr).to_pandas()
 
     assert_frame_equal(got, expect)
+
+
+def test_head():
+    np.random.seed(0)
+    df = pd.DataFrame({'x': np.random.randint(0, 5, size=100),
+                       'y': np.random.normal(size=100)})
+    gdf = gd.DataFrame.from_pandas(df)
+    dgf = dgd.from_pygdf(gdf, npartitions=2)
+
+    assert_frame_equal(dgf.head().to_pandas(), df.head())

--- a/dask_gdf/tests/test_core.py
+++ b/dask_gdf/tests/test_core.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pandas as pd
+from pandas.util.testing import assert_frame_equal
+
+import pygdf as gd
+import dask_gdf as dgd
+
+
+def test_from_pygdf():
+    df = pd.DataFrame({'x': np.random.randint(0, 5, size=10000),
+                       'y': np.random.normal(size=10000)})
+
+    gdf = gd.DataFrame.from_pandas(df)
+
+    # Test simple around to/from dask
+    ingested = dgd.from_pygdf(gdf, npartitions=2)
+    assert_frame_equal(ingested.compute().to_pandas(), df)
+
+    # Test conversion to dask.dataframe
+    ddf = ingested.to_dask_dataframe()
+    assert_frame_equal(ddf.compute(), df)

--- a/dask_gdf/tests/test_core.py
+++ b/dask_gdf/tests/test_core.py
@@ -7,6 +7,8 @@ import dask_gdf as dgd
 
 
 def test_from_pygdf():
+    np.random.seed(0)
+
     df = pd.DataFrame({'x': np.random.randint(0, 5, size=10000),
                        'y': np.random.normal(size=10000)})
 
@@ -19,3 +21,21 @@ def test_from_pygdf():
     # Test conversion to dask.dataframe
     ddf = ingested.to_dask_dataframe()
     assert_frame_equal(ddf.compute(), df)
+
+
+def test_query():
+    np.random.seed(0)
+
+    df = pd.DataFrame({'x': np.random.randint(0, 5, size=10),
+                       'y': np.random.normal(size=10)})
+    gdf = gd.DataFrame.from_pandas(df)
+    expr = 'x > 2'
+
+    assert_frame_equal(gdf.query(expr).to_pandas(), df.query(expr))
+
+    queried = (dgd.from_pygdf(gdf, npartitions=2).query(expr))
+
+    got = queried.compute().to_pandas()
+    expect = gdf.query(expr).to_pandas()
+
+    assert_frame_equal(got, expect)

--- a/dask_gdf/tests/test_reductions.py
+++ b/dask_gdf/tests/test_reductions.py
@@ -1,0 +1,45 @@
+import operator
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pygdf as gd
+import dask_gdf as dgd
+
+
+def _make_random_frame(nelem, npartitions=2):
+    df = pd.DataFrame({'x': np.random.randint(0, 5, size=nelem),
+                       'y': np.random.normal(size=nelem) + 1})
+    gdf = gd.DataFrame.from_pandas(df)
+    dgf = dgd.from_pygdf(gdf, npartitions=npartitions)
+    return df, dgf
+
+
+_reducers = [
+    'sum',
+    'count',
+    'mean',
+    'var',
+    'std',
+    'min',
+    'max',
+]
+
+
+def _get_reduce_fn(name):
+    def wrapped(series):
+        fn = getattr(series, name)
+        return fn()
+    return wrapped
+
+@pytest.mark.parametrize('reducer', _reducers)
+def test_series_reduce(reducer):
+    reducer = _get_reduce_fn(reducer)
+    np.random.seed(0)
+    size = 10
+    df, gdf = _make_random_frame(size)
+
+    got = reducer(gdf.x)
+    exp = reducer(df.x)
+    np.testing.assert_array_almost_equal(got.compute(), exp)


### PR DESCRIPTION
Update to latest pygdf (post build number 242) for API changes.
(One pending pygdf bug fix at https://github.com/gpuopenanalytics/pygdf/pull/71)

Tests are added but still not enough to cover all code path; see

```

---------- coverage: platform darwin, python 3.5.3-final-0 -----------
Name                                Stmts   Miss  Cover
-------------------------------------------------------
dask_gdf/__init__.py                    4      0   100%
dask_gdf/_version.py                  277    154    44%
dask_gdf/core.py                      336     67    80%
dask_gdf/tests/__init__.py              0      0   100%
dask_gdf/tests/test_binops.py          20      0   100%
dask_gdf/tests/test_core.py            40      0   100%
dask_gdf/tests/test_reductions.py      25      0   100%
dask_gdf/utils.py                      20      9    55%
-------------------------------------------------------
TOTAL                                 722    230    68%
```



