### PR TITLE
Avoid overhead due to recompilation

### DIFF
--- a/dask_gdf/core.py
+++ b/dask_gdf/core.py
@@ -342,9 +342,13 @@ class DataFrame(_Frame):
         meta = assigner(self._meta, k, make_meta(v))
         return self.map_partitions(assigner, k, v, meta=meta)
 
-    def apply_rows(self, func, incols, outcols, kwargs={}):
+    def apply_rows(self, func, incols, outcols, kwargs={}, cache_key=None):
+        import uuid
+        if cache_key is None:
+            cache_key = uuid.uuid4()
         def do_apply_rows(df, func, incols, outcols, kwargs):
-            return df.apply_rows(func, incols, outcols, kwargs)
+            return df.apply_rows(func, incols, outcols, kwargs,
+                                 cache_key=cache_key)
 
         meta = do_apply_rows(self._meta, func, incols, outcols, kwargs)
         return self.map_partitions(do_apply_rows, func, incols, outcols, kwargs,

--- a/dask_gdf/groupby.py
+++ b/dask_gdf/groupby.py
@@ -47,7 +47,7 @@ class Groupby(object):
         return self._aggregation(lambda df: df.agg(mapping),
                                  lambda df: df.agg(mapping))
 
-    def _aggregation(self, chunk, combine, split_every=8):
+    def _aggregation(self, chunk, combine, split_every=4):
         by = self._by
 
         @delayed


### PR DESCRIPTION
Depends on https://github.com/gpuopenanalytics/pygdf/pull/107
Add cache_key to apply_rows.