### PR TITLE
[REVIEW] Removed error when using datetime/timedelta

### DIFF
--- a/dask_gdf/core.py
+++ b/dask_gdf/core.py
@@ -437,10 +437,9 @@ def from_dask_dataframe(df):
     ----------
     df : dask.dataframe.DataFrame
     """
-    bad_cols = df.select_dtypes(include=['O', 'M', 'm'])
+    bad_cols = df.select_dtypes(include=['O'])
     if len(bad_cols.columns):
-        raise ValueError("Object, datetime, or timedelta dtypes aren't "
-                         "supported by pygdf")
+        raise ValueError("Object dtypes aren't supported by pygdf")
 
     meta = _from_pandas(df._meta)
     dummy = DataFrame(df.dask, df._name, meta, df.divisions)


### PR DESCRIPTION
This PR removes the assumption that Pygdf doesn't support datetime or timedelta types as they are now supported.