### PR TITLE
Improved binary operators test.

### DIFF
--- a/dask_gdf/tests/test_binops.py
+++ b/dask_gdf/tests/test_binops.py
@@ -8,7 +8,20 @@ import pygdf as gd
 import dask_gdf as dgd
 
 
+def _make_empty_frame(npartitions=2):
+    df = pd.DataFrame({'x': [], 'y': []})
+    gdf = gd.DataFrame.from_pandas(df)
+    dgf = dgd.from_pygdf(gdf, npartitions=npartitions)
+    return dgf
+
 def _make_random_frame(nelem, npartitions=2):
+    df = pd.DataFrame({'x': np.random.random(size=nelem),
+                       'y': np.random.random(size=nelem)})
+    gdf = gd.DataFrame.from_pandas(df)
+    dgf = dgd.from_pygdf(gdf, npartitions=npartitions)
+    return df, dgf
+
+def _make_random_frame_float(nelem, npartitions=2):
     df = pd.DataFrame({'x': np.random.randint(0, 5, size=nelem),
                        'y': np.random.normal(size=nelem) + 1})
     gdf = gd.DataFrame.from_pandas(df)
@@ -30,13 +43,28 @@ _binops = [
     operator.le,
 ]
 
+@pytest.mark.parametrize('binop', _binops)
+def test_series_binops_empty(binop):
+    with pytest.raises(ValueError, match=r'.*size=0.*'):
+        gdf = _make_empty_frame()
+        got = binop(gdf.x, gdf.y)
 
 @pytest.mark.parametrize('binop', _binops)
-def test_series_binops(binop):
+def test_series_binops_integer(binop):
     np.random.seed(0)
-    size = 10
+    size = 1000000
     lhs_df, lhs_gdf = _make_random_frame(size)
     rhs_df, rhs_gdf = _make_random_frame(size)
+    got = binop(lhs_gdf.x, rhs_gdf.y)
+    exp = binop(lhs_df.x, rhs_df.y)
+    np.testing.assert_array_almost_equal(got.compute().to_array(), exp)
+
+@pytest.mark.parametrize('binop', _binops)
+def test_series_binops_float(binop):
+    np.random.seed(0)
+    size = 1000000
+    lhs_df, lhs_gdf = _make_random_frame_float(size)
+    rhs_df, rhs_gdf = _make_random_frame_float(size)
     got = binop(lhs_gdf.x, rhs_gdf.y)
     exp = binop(lhs_df.x, rhs_df.y)
     np.testing.assert_array_almost_equal(got.compute().to_array(), exp)


### PR DESCRIPTION
The test is related to the former python bindings of binary operators, that is to say, it's related to the file 'binaryops.cu' in libgdf. It is not related to the new implementation of binary operators using Jitify/NVRTC.

The objectives of the improvement are about:
- Add an additional type (float) for testing.
- Increase the size of elements in the Dataframe.
- Test the exception thrown when an empty Dataframe is used.

A requirement for this improvement is to merge locally the master branch with another three branches (fea-ext-no-div-concat, bug-ext-groupby-key and fea-ext-setitem) that are currently under development (PR) and work over a new branch based on the merged branches.

The PR only has the changes made over the test file, therefore, it doesn't have the changes of the merged branches.
